### PR TITLE
Add new special operator case for tampere

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,10 @@
 def parse_route_id(feed, route_id, trip_id, otp_data):
     if feed == "tampere":
+        if len(route_id) > 6 and route_id[-6:] == "701871":
+            return route_id[0:-6]
         if len(route_id) > 5 and (route_id[-5:] == "47374" or route_id[-5:] == "56920"):
             return route_id[0:-5]
-        else:
-            return route_id[0:-4]
+        return route_id[0:-4]
     elif feed == "OULU":
         feed_scoped_id = "OULU:" + trip_id
         if otp_data == None or feed_scoped_id not in otp_data:


### PR DESCRIPTION
Route with 103701871 id from realtime system now gets wrongly parsed as 10370 as it uses the default parsing rule. This adds a new rule.