### PR TITLE
feat: don't send updates for which newer info was sent

### DIFF
--- a/gtfsrthttp2mqtt.py
+++ b/gtfsrthttp2mqtt.py
@@ -39,7 +39,6 @@ class GTFSRTHTTP2MQTTTransformer:
         self.session.mount(gtfsrtFeedURL, adapter)
         self.session.headers.update(json.loads(gtfsrtFeedHeaders))
         self.OTPData = None
-        self.tripTimestamps = {}
 
 
 
@@ -95,12 +94,6 @@ class GTFSRTHTTP2MQTTTransformer:
                 nent.CopyFrom(entity)
 
                 trip_id = entity.vehicle.trip.trip_id
-                if trip_id is not None and trip_id in self.tripTimestamps and self.tripTimestamps[trip_id] > nfeedmsg.header.timestamp:
-                    # received older position for vehicle, to avoid back and forth jumping positions
-                    # just ignore that message
-                    continue
-                elif trip_id is not None:
-                    self.tripTimestamps[trip_id] = nfeedmsg.header.timestamp
                 route_id = utils.parse_route_id(self.feedName, entity.vehicle.trip.route_id, trip_id, self.OTPData)
                 direction_id = entity.vehicle.trip.direction_id
                 trip_headsign = entity.vehicle.vehicle.label
@@ -170,8 +163,6 @@ class GTFSRTHTTP2MQTTTransformer:
                 del element['gtfsId']
                 data_dictionary[gtfsId] = element
             self.OTPData = data_dictionary
-            # Reset tripTimestamps to avoid caching outdated tripIds
-            self.tripTimestamps = {}
 
 if __name__ == '__main__':
     gh2mt = GTFSRTHTTP2MQTTTransformer(


### PR DESCRIPTION
This PR stores the message-timestamp of the latest sent message per tripId and skips messages older than this timestamp.

Background of this addition: our local transit agency apparently uses multiple load balancing servers to serve gtfsrt feeds, which sadly are not in sync. This results in vehicles jumping back and forth on the map, as for subsequent calls older positions are sent after the vehicle already has moved forward.

Please let me know, if you are willing to accept this workaround for a misbehaving gtfsrt producer as upstream contribution. Otherwise, we'll consider running a custom fork.